### PR TITLE
Remove "Controlled Document" references

### DIFF
--- a/docs/handbook/this-site/controlled-documents.md
+++ b/docs/handbook/this-site/controlled-documents.md
@@ -1,9 +1,0 @@
-# Controlled documents
-
-This is currently a placeholder page.
-
-!!! example "Work in progress"
-    This page is a work in progress, and will undergo additional changes. Please check back.
-
-!!! danger "Controlled Document"
-    Inline with our internal policy as well as legal and contractual obligations, changes to [Controlled Documents](handbook/this-site/controlled-documents.md) must be approved and merged by an admin. Please discuss with @thhsh or another admin before making any changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,11 +30,6 @@ This site is subject to interpretation. We do our best to be as clear as possibl
 
     Please see the [:material-pencil: Editing this Site](handbook/this-site/editing-this-site.md) section for more information.
 
-!!! danger "Controlled Documents"
-    If you come across pages/documents with this header, that indicates that they are a Controlled Document.
-
-    Inline with our internal policy as well as legal and contractual obligations, changes to [Controlled Documents](handbook/this-site/controlled-documents.md) must be approved and merged by an admin. Please discuss with @thhsh or another admin before making any changes.
-
 ## :fontawesome-brands-creative-commons: License
 This work is licensed under [CC BY-SA 4.0. :fontawesome-brands-creative-commons::fontawesome-brands-creative-commons-by::fontawesome-brands-creative-commons-sa:](https://creativecommons.org/licenses/by-sa/4.0/)
 

--- a/docs/policies/index.md
+++ b/docs/policies/index.md
@@ -4,6 +4,3 @@ This is currently a placeholder page.
 
 !!! example "Work in progress"
     This page is a work in progress, and will undergo additional changes. Please check back.
-
-!!! danger "Controlled Document"
-    Inline with our internal policy as well as legal and contractual obligations, changes to [Controlled Documents](handbook/this-site/controlled-documents.md) must be approved and merged by an admin. Please discuss with @thhsh or another admin before making any changes.


### PR DESCRIPTION
Remove "Controlled Document" references from index, policies, and editing pages.